### PR TITLE
Proposed fix for object detection config file. 

### DIFF
--- a/config/markers_configuration_sample.yml
+++ b/config/markers_configuration_sample.yml
@@ -11,10 +11,10 @@
 # by the object detector. The size of the marker is 20x20 (the unit does not
 # matter, but must be consistent with the calibration unit. We recommend to use
 # millimeters).
-# This simple declaration allows to define name aliases for markers. 'marker'
+# This simple declaration allows to define name aliases for markers. 'tag'
 # and 'size' are the only two mandatory fields.
 myobject1:
-    - marker: 0
+    - tag: 0
       size: 20
 
 # The second object also has a single marker, but translated and rotated.  The
@@ -24,7 +24,7 @@ myobject1:
 # on the X axis followed by a rotation on the Y axis, followed by a rotation on
 # the Z axis.
 myobject2:
-    - marker: 1
+    - tag: 1
       size: 30
       translation: [10., 0., 0.]
       rotation: [0., 0., 90.]
@@ -34,14 +34,14 @@ myobject2:
 # If a marker sets the option 'keep' to 'true', the marker 3D position is
 # returned besides the object.
 myobject3:
-    - marker: 2
+    - tag: 2
       size: 20
       translation: [-50., -100., 0.0]
       keep: true
-    - marker: 3
+    - tag: 3
       size: 30
       translation: [50., -100., 0.0]
-    - marker: 4
+    - tag: 4
       size: 30
       translation: [50., 100., 0.0]
 


### PR DESCRIPTION
Logic in Chilitags3D.cpp requires that the marker ID be identified with a 'tag' key name, not 'marker' key name.